### PR TITLE
Add work arrangement options to job postings and display them on cards

### DIFF
--- a/.replit
+++ b/.replit
@@ -38,3 +38,6 @@ author = "agent"
 task = "shell.exec"
 args = "npm run dev"
 waitForPort = 5000
+
+[agent]
+expertMode = true

--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, WORK_ARRANGEMENTS } from "@shared/schema";
 import type { InsertProspect } from "@shared/schema";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      workArrangement: null,
       notes: "",
       salaryCurrency: "",
       salaryAmount: null,
@@ -158,6 +159,32 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="workArrangement"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Work Arrangement (optional)</FormLabel>
+              <Select onValueChange={(val) => field.onChange(val === "none" ? null : val)} value={field.value ?? "none"}>
+                <FormControl>
+                  <SelectTrigger data-testid="select-work-arrangement">
+                    <SelectValue placeholder="Select arrangement" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="none" data-testid="option-arrangement-none">None</SelectItem>
+                  {WORK_ARRANGEMENTS.map((arr) => (
+                    <SelectItem key={arr} value={arr} data-testid={`option-arrangement-${arr}`}>
+                      {arr}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <div className="grid grid-cols-2 gap-4">
           <FormField

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, WORK_ARRANGEMENTS } from "@shared/schema";
 import type { InsertProspect, Prospect } from "@shared/schema";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      workArrangement: (prospect.workArrangement as InsertProspect["workArrangement"]) ?? null,
       notes: prospect.notes ?? "",
       salaryCurrency: prospect.salaryCurrency ?? "",
       salaryAmount: prospect.salaryAmount ?? null,
@@ -162,6 +163,32 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="workArrangement"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Work Arrangement (optional)</FormLabel>
+              <Select onValueChange={(val) => field.onChange(val === "none" ? null : val)} value={field.value ?? "none"}>
+                <FormControl>
+                  <SelectTrigger data-testid="select-edit-work-arrangement">
+                    <SelectValue placeholder="Select arrangement" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="none" data-testid="option-edit-arrangement-none">None</SelectItem>
+                  {WORK_ARRANGEMENTS.map((arr) => (
+                    <SelectItem key={arr} value={arr} data-testid={`option-edit-arrangement-${arr}`}>
+                      {arr}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <div className="grid grid-cols-2 gap-4">
           <FormField

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -38,6 +38,32 @@ function InterestIndicator({ level }: { level: string }) {
   }
 }
 
+function WorkArrangementIndicator({ arrangement }: { arrangement: string | null }) {
+  if (!arrangement) return null;
+  switch (arrangement) {
+    case "Remote":
+      return (
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-blue-500 dark:text-blue-400" data-testid="arrangement-remote">
+          🏠 Remote
+        </span>
+      );
+    case "Hybrid":
+      return (
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-purple-500 dark:text-purple-400" data-testid="arrangement-hybrid">
+          🔀 Hybrid
+        </span>
+      );
+    case "Onsite":
+      return (
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-orange-500 dark:text-orange-400" data-testid="arrangement-onsite">
+          🏢 Onsite
+        </span>
+      );
+    default:
+      return null;
+  }
+}
+
 export function ProspectCard({ prospect }: { prospect: Prospect }) {
   const { toast } = useToast();
   const [editOpen, setEditOpen] = useState(false);
@@ -102,6 +128,7 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          <WorkArrangementIndicator arrangement={prospect.workArrangement} />
         </div>
 
         {prospect.salaryAmount != null && (

--- a/replit.md
+++ b/replit.md
@@ -30,10 +30,12 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, work_arrangement, salary_currency, salary_amount, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
-- **Interest levels**: High, Medium, Low
+- **Interest levels**: High (🔥), Medium (👍), Low (🤷)
+- **Work arrangements**: Remote (🏠), Hybrid (🔀), Onsite (🏢) — optional field
+- **Salary**: currency (text) + amount (integer) — optional, shown with 💰
 
 ## API
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -153,3 +153,78 @@ describe("salary input validation", () => {
     expect(result.valid).toBe(true);
   });
 });
+
+describe("work arrangement validation", () => {
+  test("accepts Remote work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      workArrangement: "Remote",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts Hybrid work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      workArrangement: "Hybrid",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts Onsite work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      workArrangement: "Onsite",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts null work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      workArrangement: null,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts undefined work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects invalid work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      workArrangement: "PartTime",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Work arrangement must be one of: Remote, Hybrid, Onsite");
+  });
+
+  test("accepts valid prospect with all fields including work arrangement", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      workArrangement: "Remote",
+      salaryAmount: 150000,
+      salaryCurrency: "USD",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -1,4 +1,4 @@
-import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS, WORK_ARRANGEMENTS } from "@shared/schema";
 
 export function getNextStatus(currentStatus: string): string {
   const terminalStatuses = ["Offer", "Rejected", "Withdrawn"];
@@ -36,6 +36,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
   if (data.interestLevel !== undefined) {
     if (!INTEREST_LEVELS.includes(data.interestLevel as (typeof INTEREST_LEVELS)[number])) {
       errors.push(`Interest level must be one of: ${INTEREST_LEVELS.join(", ")}`);
+    }
+  }
+
+  if (data.workArrangement !== undefined && data.workArrangement !== null) {
+    if (!WORK_ARRANGEMENTS.includes(data.workArrangement as (typeof WORK_ARRANGEMENTS)[number])) {
+      errors.push(`Work arrangement must be one of: ${WORK_ARRANGEMENTS.join(", ")}`);
     }
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -45,6 +45,7 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = parsed.data.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = parsed.data.jobUrl;
     if (body.notes !== undefined) updates.notes = parsed.data.notes;
+    if (body.workArrangement !== undefined) updates.workArrangement = parsed.data.workArrangement;
     if (body.salaryCurrency !== undefined) updates.salaryCurrency = parsed.data.salaryCurrency;
     if (body.salaryAmount !== undefined) updates.salaryAmount = parsed.data.salaryAmount;
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -14,6 +14,8 @@ export const STATUSES = [
 
 export const INTEREST_LEVELS = ["High", "Medium", "Low"] as const;
 
+export const WORK_ARRANGEMENTS = ["Remote", "Hybrid", "Onsite"] as const;
+
 export const prospects = pgTable("prospects", {
   id: serial("id").primaryKey(),
   companyName: text("company_name").notNull(),
@@ -22,6 +24,7 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  workArrangement: text("work_arrangement"),
   salaryCurrency: text("salary_currency"),
   salaryAmount: integer("salary_amount"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -37,6 +40,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  workArrangement: z.enum(WORK_ARRANGEMENTS).optional().nullable(),
   salaryCurrency: z.string().optional().nullable(),
   salaryAmount: z.number().int().min(0, "Salary must be a positive number").optional().nullable(),
 });


### PR DESCRIPTION
Adds a new 'workArrangement' field to job postings, allowing users to select 'Remote', 'Hybrid', or 'Onsite'. This includes updates to forms, the prospect card display, API routes, and validation tests.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 4f070e1f-4bd9-4ebd-980f-0012607d5b4e
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 665a09c7-88bf-4090-b959-92aef71e1852
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8a4778d8-0a3d-48b1-a739-b77f460f2adb/4f070e1f-4bd9-4ebd-980f-0012607d5b4e/eeJmifN
Replit-Helium-Checkpoint-Created: true